### PR TITLE
Upgrade to Node.js 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
       - run: npm ci
       - run: npm test
   test:

--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ inputs:
     default: "3"
     description: 'Number of times to retry fetching secrets'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary
- Update action runtime from `node20` to `node24`
- Update CI workflow to use Node.js 24 for unit tests

## Test plan
- [ ] CI pipeline passes with Node.js 24
- [ ] Integration test job runs successfully with the updated action runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)